### PR TITLE
Add ability to toggle postgres chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -20,6 +20,10 @@ version: 0.1.0
 # incremented each time you make changes to the application.
 appVersion: 1.16.0
 
+dependencies:
+  - name: postgresql
+    condition: postgresql.enabled
+
 # WIP
 #dependencies: 
 #  - name: nginx-ingress

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -71,12 +71,6 @@ spec:
             {{- end}}
           - name: DEST_TRANSFORM_URL
             value: "http://{{ include "transformer.fullname" . }}:{{ .Values.transformer.service.port}}"
-          - name: COMPUTE_DB_HOST_IN_K8S
-            value: "true"
-          - name: POSTGRES_POD_NAME
-            value: "{{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}"
-          - name: POSTGRES_HEADLESS_SVC
-            value: "{{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}-headless"
           - name: JOBS_DB_HOST
             value: "This is expected to be set by docker entrypoint script"
           - name: JOBS_DB_USER
@@ -93,6 +87,14 @@ spec:
                 fieldPath: metadata.name
           - name: KUBE_NAMESPACE
             value: {{ .Release.Namespace }}
+          {{- if .Values.postgresql.enabled }}
+          - name: COMPUTE_DB_HOST_IN_K8S
+            value: "true"
+          - name: POSTGRES_POD_NAME
+            value: "{{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}"
+          - name: POSTGRES_HEADLESS_SVC
+            value: "{{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}-headless"
+          {{- end }}
         command: ["/docker-entrypoint.sh"]
         args: ["/bin/sh","-c","/wait-for $JOBS_DB_HOST:$(JOBS_DB_PORT) -- /rudder-server"]
         {{- if .Values.telegraf_sidecar.enabled}}

--- a/values.yaml
+++ b/values.yaml
@@ -98,6 +98,7 @@ transformer:
       memory: 768Mi
 
 postgresql:
+  enabled: true
   nameOverride: "rudderstack-postgresql"
   postgresqlUsername: rudder
   postgresqlPassword: password


### PR DESCRIPTION
## Description of the change

Adds `postgresql.enabled` value to give control over postgresql subchart and specific postgres related env vars.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#16]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
