### PR TITLE
Add ingress template

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.backend.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "rudderstack.fullname" . }}
+  labels:
+    {{- include "rudderstack.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.backend.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.backend.ingress.tls }}
+  tls:
+    - hosts:
+      - {{ .Values.backend.ingress.hostname | quote }}
+      secretName: {{ .Values.backend.ingress.secretName | default (printf "%s-tls" (include "rudderstack.fullname" .)) }}
+{{- end }}
+  rules:
+    - host: {{ .Values.backend.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ include "rudderstack.fullname" . }}
+              servicePort: {{ .Values.backend.service.port }}
+{{- end -}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -21,7 +21,10 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ include "rudderstack.fullname" . }}
-              servicePort: {{ .Values.backend.service.port }}
+              service:
+                name: {{ include "rudderstack.fullname" . }}
+                port:
+                  number: {{ .Values.backend.service.port }}
 {{- end -}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.backend.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "rudderstack.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -32,7 +32,7 @@ backend:
   ingress:
     enabled: false
     tls: false
-    annotations:
+    annotations: {}
     hostname: "rudderstack.local"
   service:
     annotations:

--- a/values.yaml
+++ b/values.yaml
@@ -34,6 +34,8 @@ backend:
     tls: false
     annotations: {}
     hostname: "rudderstack.local"
+    # optional override for tls secret name
+    # secretName: rudderstack-tls
   service:
     annotations:
       ## Refer https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer for more annotations

--- a/values.yaml
+++ b/values.yaml
@@ -29,6 +29,11 @@ backend:
     version: 1-alpine
     pullPolicy: Always
   controlPlaneJSON: false
+  ingress:
+    enabled: false
+    tls: false
+    annotations:
+    hostname: "rudderstack.local"
   service:
     annotations:
       ## Refer https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer for more annotations


### PR DESCRIPTION
## Description of the change

This PR adds an optional `ingress` resource to the chart templates. The resource is disabled by default and can be enabled with `backend.ingress.enabled`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #17 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

Linting generates

```
[WARNING] templates/ingress.yaml: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```

But perhaps it's better to be more backwards compatible(?)

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
