### PR TITLE
support google application credentials json in a a secret

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/secret-gcp.yaml
+++ b/templates/secret-gcp.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.gcpCredentialSecret.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "rudderstack.fullname" . }}-gcp
+  labels:
+    {{- include "rudderstack.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  google-application-credentials.json: {{ .Values.gcpCredentialSecret.jsonKeyFile | quote }}
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -33,7 +33,12 @@ spec:
             defaultMode: 420
             name: {{ include "telegraf-sidecar.fullname" . }}-config
         {{- end }}
-
+        {{- if .Values.gcpCredentialSecret.enabled }}
+        - name: google-application-credentials
+          secret:
+            defaultMode: 420
+            secretName: {{ include "rudderstack.fullname" . }}-gcp
+        {{- end }}
       containers:
       - name: {{ include "backend.name" . }}
         image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.version }}"
@@ -43,6 +48,10 @@ spec:
           name: backend-config-volume
         - mountPath: {{ .Values.backend.persistence.mountPath }}
           name: {{ include "backend.name" . }}-data
+        {{- if .Values.gcpCredentialSecret.enabled }}
+        - mountPath: {{ .Values.gcpCredentialSecret.mountPath }}
+          name: google-application-credentials
+        {{- end }}
         ports:
           - name: backend
             containerPort: {{ .Values.backend.service.targetPort }}

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,10 @@
 # Please enter api token obtained from rudder dashboard below
 # rudderWorkspaceToken:
 
+gcpCredentialSecret:
+  enabled: false
+  jsonKeyFile: ""
+  mountPath: /etc/gcp
 
 global:
   # backendReplicaCount decides the replica count for rudder backend and postgresql containers


### PR DESCRIPTION
## Description of the change

support storing the google application credentials in a secret. might want to consider deprecating storing them in a configmap, but for now i have left that option since i didn't want to break any existing functionality.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
