### PR TITLE
updated ingress template and values to work with GKE http load balancer

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -16,15 +16,9 @@ spec:
       - {{ .Values.backend.ingress.hostname | quote }}
       secretName: {{ .Values.backend.ingress.secretName | default (printf "%s-tls" (include "rudderstack.fullname" .)) }}
 {{- end }}
-  rules:
-    - host: {{ .Values.backend.ingress.hostname }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "rudderstack.fullname" . }}
-                port:
-                  number: {{ .Values.backend.service.port }}
+  defaultBackend:
+    service:
+      name: {{ include "rudderstack.fullname" . }}
+      port:
+        number: {{ .Values.backend.service.port }}
 {{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -30,20 +30,22 @@ backend:
     pullPolicy: Always
   controlPlaneJSON: false
   ingress:
-    enabled: false
+    enabled: true
     tls: false
-    annotations: {}
+    annotations: 
+      kubernetes.io/ingress.global-static-ip-name: <staticIP>
     hostname: "rudderstack.local"
     # optional override for tls secret name
     # secretName: rudderstack-tls
   service:
     annotations:
+      cloud.google.com/neg: '{"ingress": false}'
       ## Refer https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer for more annotations
-      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+      # service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
       ## For enabling https on aws, 
       ## uncomment below line with acm managed certificate arn and change port value below to 443
       # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012
-    type: LoadBalancer
+    type: NodePort
     port: 80
     targetPort: 8080
   resources:


### PR DESCRIPTION
## Description of the change

These changes to the helm chart were needed to get it working for us on GKE. 

This PR changes the service from type `LoadBalancer` to `NodePort` and enables the kubernetes Ingress. It also specifies the correct google annotations to use a reserved static IP and prevent the ingress from creating an NEG (Network Endpoint Group). This will cause google to create an "External HTTP load balancer" instead of using TCP. You can then optionally connect an https-target-proxy, forwarding rule on 443 and a google managed cert to support SSL/TLS. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Addresses issue [#20]()


## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
