### PR TITLE
Support using a custom service account

### DIFF
--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.backend.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.backend.serviceAccount.name }}
+  labels:
+    {{- include "rudderstack.labels" . | nindent 4 }}
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -22,6 +22,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      serviceAccountName: {{ .Values.backend.serviceAccount.name }}
       volumes:
         - configMap:
             defaultMode: 420

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
 # Deployment specific values for rudderstack.
 # Following values must be filled in for the deployment to succeed
 
@@ -44,7 +43,7 @@ backend:
     annotations:
       ## Refer https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer for more annotations
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-      ## For enabling https on aws, 
+      ## For enabling https on aws,
       ## uncomment below line with acm managed certificate arn and change port value below to 443
       # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012
     type: LoadBalancer
@@ -55,6 +54,9 @@ backend:
       memory: 2560Mi
     limits:
       memory: 5120Mi
+  serviceAccount:
+    create: false
+    name: default
 
   nodeSelector: {}
 


### PR DESCRIPTION
## Description of the change
Adds an option (`backend.serviceAccount.name`) to use a non-default service account for the statefulset. The option `backend.serviceAccount.create` allows the service account to be managed by the helm chart or externally.

Existing functionality is unchanged because the default values continue to use the `default` service account.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
