### PR TITLE
Move `rudderWorkspaceToken` to a secret

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The following table lists the configurable parameters of the Rudderstack chart a
 | Parameter                           | Description                                                                                         | Default                  |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------ |
 | `rudderWorkspaceToken`              | Workspace token from the dashboard                                                                  | `-`                      |
+| `rudderWorkspaceTokenSecretName`    | Secret with workspace token (overrides `rudderWorkspaceToken`)                                                                 | `-`                      |
 | `backend.image.repository`          | Container image repository for the backend                                                          | `rudderlabs/rudder-server`     |
 | `backend.image.version`                 | Container image tag for the backend. [Available versions](https://hub.docker.com/r/rudderlabs/rudder-server/tags)                                                                 | `v0.1.6`                  |
 | `backend.image.pullPolicy`     | Container image pull policy for the backend image                                                   | `Always`           |

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The following table lists the configurable parameters of the Rudderstack chart a
 | Parameter                           | Description                                                                                         | Default                  |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------ |
 | `rudderWorkspaceToken`              | Workspace token from the dashboard                                                                  | `-`                      |
-| `rudderWorkspaceTokenSecretName`    | Secret with workspace token (overrides `rudderWorkspaceToken`)                                                                 | `-`                      |
+| `rudderWorkspaceTokenExistingSecret`    | Secret with workspace token (overrides `rudderWorkspaceToken`)                                                                 | `-`                      |
 | `backend.image.repository`          | Container image repository for the backend                                                          | `rudderlabs/rudder-server`     |
 | `backend.image.version`                 | Container image tag for the backend. [Available versions](https://hub.docker.com/r/rudderlabs/rudder-server/tags)                                                                 | `v0.1.6`                  |
 | `backend.image.pullPolicy`     | Container image pull policy for the backend image                                                   | `Always`           |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -51,6 +51,13 @@ app.kubernetes.io/name: {{ include "rudderstack.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{/*
+Return secret name to be used based on provided values.
+*/}}
+{{- define "rudderstack.rudderWorkspaceTokenSecretName" -}}
+{{- default (include "rudderstack.fullname" .) .Values.rudderWorkspaceTokenExistingSecret -}}
+{{- end -}}
+
 {{- define "transformer.name" -}}
 {{- printf "%s-%s" (include "rudderstack.name" .) "transformer" -}}
 {{- end -}}

--- a/templates/secret-rudder-token.yaml
+++ b/templates/secret-rudder-token.yaml
@@ -8,6 +8,6 @@ metadata:
     {{- include "rudderstack.labels" . | nindent 4 }}
 type: Opaque
 data:
-  rudderWorkspaceToken: {{ default "MISSING" .Values.rudderWorkspaceToken | b64enc | quote }}
+   rudderWorkspaceToken: {{ required "value for either .Values.rudderWorkspaceTokenExistingSecret or .Values.rudderWorkspaceToken is expected" .Values.rudderWorkspaceToken | b64enc | quote }}
 {{- end }}
 

--- a/templates/secret-rudder-token.yaml
+++ b/templates/secret-rudder-token.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.rudderWorkspaceTokenExistingSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rudderstack.rudderWorkspaceTokenSecretName" . }}
+  labels:
+    {{- include "rudderstack.labels" . | nindent 4 }}
+type: Opaque
+data:
+  rudderWorkspaceToken: {{ default "MISSING" .Values.rudderWorkspaceToken | b64enc | quote }}
+{{- end }}
+

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         {{- include "rudderstack.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- if not .Values.rudderWorkspaceTokenExistingSecret }}
+        checksum/rudder-workspace-token: {{ include (print $.Template.BasePath "/secret-rudder-token.yaml") . | sha256sum }}
+        {{- end }}
         checksum/rudder-config: {{ .Files.Get "rudder-config.yaml" | sha256sum }}
         checksum/rudder-bigquery-credentials: {{ .Files.Get "bigquery-credentials.json" | sha256sum }}
     spec:
@@ -71,7 +74,10 @@ spec:
             {{- .Values.backend.extraEnvVars | toYaml | nindent 10 }}
           {{- end }}
           - name: CONFIG_BACKEND_TOKEN
-            value: {{ .Values.rudderWorkspaceToken }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "rudderstack.rudderWorkspaceTokenSecretName" . }}
+                key: rudderWorkspaceToken
             {{- if .Values.backend.controlPlaneJSON }}
           - name: RSERVER_BACKEND_CONFIG_CONFIG_FROM_FILE
             value: "{{ .Values.backend.controlPlaneJSON }}"

--- a/values.yaml
+++ b/values.yaml
@@ -7,8 +7,9 @@
 # Following values must be filled in for the deployment to succeed
 
 # Please uncomment below lines and fill values accordingly.
-# Please enter api token obtained from rudder dashboard below
+# Please enter api token obtained from rudder dashboard below or specify existing secret, that contains rudderWorkspaceToken key
 # rudderWorkspaceToken:
+#rudderWorkspaceTokenSecretName:
 
 gcpCredentialSecret:
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -9,7 +9,7 @@
 # Please uncomment below lines and fill values accordingly.
 # Please enter api token obtained from rudder dashboard below or specify existing secret, that contains rudderWorkspaceToken key
 # rudderWorkspaceToken:
-#rudderWorkspaceTokenSecretName:
+# rudderWorkspaceTokenExistingSecret:
 
 gcpCredentialSecret:
   enabled: false


### PR DESCRIPTION
## Description of the change

Move `rudderWorkspaceToken` to a secret to improve security in managed clusters.
Allow use of pre-created secrets to allow integration with other secret managing tools (ExternalSecrets, etc.)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
