### PR TITLE
add missing default configuration Gateway.webhook.sourceListForParsingParams

### DIFF
--- a/rudder-config.yaml
+++ b/rudder-config.yaml
@@ -35,6 +35,8 @@ Gateway:
     maxTransformerProcess: 64
     maxRetry: 5
     maxRetryTime: 10s
+    sourceListForParsingParams:
+      - shopify
 EventSchemas:
   enableEventSchemasFeature: false
   syncInterval: 240s


### PR DESCRIPTION
Fix issue: https://github.com/rudderlabs/rudderstack-helm/issues/45

## Description of the change

The config/config.yaml in this helm chart is missing the default configuration for sourceListForParsingParams: https://github.com/rudderlabs/rudder-server/blob/59a33f8fb2f12a775e4663add0f4b7f3ff4fd9b5/config/config.yaml#L38-L39

This leads to a processing error of shopify webhooks, because the code did not inject the query_parameters into the transformer json (https://github.com/rudderlabs/rudder-server/blob/4348f9f0cdfa488849a6dd755946c9f1f8c77838/gateway/webhook/webhook.go#L251):

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#45](https://github.com/rudderlabs/rudderstack-helm/issues/45) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
