### PR TITLE
add wait-for condition for telegraf

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -104,16 +104,12 @@ Return the appropriate apiVersion for statefulset.
 {{- define "statsd.enabled" -}}
 {{- if .Values.telegraf_sidecar.enabled -}}
 true
-{{- else -}}
-{{.Values.telegraf.enabled }}
 {{- end -}}
 {{- end -}}
 
 {{- define "statsd.url" -}}
 {{- if .Values.telegraf_sidecar.enabled -}}
 {{- printf "localhost:8125" }}
-{{- else -}}
-{{include "telegraf.fullname" .}}:{{.Values.telegraf.service.port }}
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -93,6 +93,29 @@ Return the appropriate apiVersion for statefulset.
 {{- end -}}
 {{- end -}}
 
+{{- define "backend.binary" -}}
+{{- if .Values.backend.raceEnabled -}}
+/rudder-server-with-race
+{{- else -}}
+/rudder-server
+{{- end -}}
+{{- end -}}
+
+{{- define "statsd.enabled" -}}
+{{- if .Values.telegraf_sidecar.enabled -}}
+true
+{{- else -}}
+{{.Values.telegraf.enabled }}
+{{- end -}}
+{{- end -}}
+
+{{- define "statsd.url" -}}
+{{- if .Values.telegraf_sidecar.enabled -}}
+{{- printf "localhost:8125" }}
+{{- else -}}
+{{include "telegraf.fullname" .}}:{{.Values.telegraf.service.port }}
+{{- end -}}
+{{- end -}}
 
 
 {{/*telegraf helper functions */}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -102,14 +102,24 @@ Return the appropriate apiVersion for statefulset.
 {{- end -}}
 
 {{- define "statsd.enabled" -}}
-{{- if .Values.telegraf_sidecar.enabled -}}
-true
+{{- if .Values.telegraf_sidecar -}}
+{{- if .Values.telegraf_sidecar.enabled }}
+{{ .Values.telegraf_sidecar.enabled }}
+{{- end -}}
+{{- else -}}
+{{ fail "Telegraf sidecar block doesn't exist in values.yaml ." }}
 {{- end -}}
 {{- end -}}
 
 {{- define "statsd.url" -}}
+{{- if .Values.telegraf_sidecar -}}
 {{- if .Values.telegraf_sidecar.enabled -}}
 {{- printf "localhost:8125" }}
+{{- else -}}
+{{ fail "Sidecar Telegraf is not enabled. We can't deduce statsd url." }}
+{{- end -}}
+{{- else -}}
+{{ fail "Telegraf sidecar block doesn't exist in values.yaml . We can't deduce statsd url." }}
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -93,14 +93,6 @@ Return the appropriate apiVersion for statefulset.
 {{- end -}}
 {{- end -}}
 
-{{- define "backend.binary" -}}
-{{- if .Values.backend.raceEnabled -}}
-/rudder-server-with-race
-{{- else -}}
-/rudder-server
-{{- end -}}
-{{- end -}}
-
 {{- define "statsd.enabled" -}}
 {{- if .Values.telegraf_sidecar -}}
 {{- if .Values.telegraf_sidecar.enabled }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
           - name: KUBE_NAMESPACE
             value: {{ .Release.Namespace }}
         command: ["/docker-entrypoint.sh"]
-        args: ["/bin/sh","-c","/wait-for $JOBS_DB_HOST:$(JOBS_DB_PORT) -- /rudder-server"]
+        args: ["/bin/sh","-c","/wait-for $JOBS_DB_HOST:$(JOBS_DB_PORT) {{ if eq (include "statsd.enabled" .) "true" -}} -- /wait-for -u {{ include "statsd.url" .}} {{- end }} -- {{include "backend.binary" .}} {{ .Values.backend.cliArgs }}"]
         {{- if .Values.telegraf_sidecar.enabled}}
       - name: {{ include "telegraf-sidecar.name" .}}
         image: "{{ .Values.telegraf_sidecar.image.repo }}:{{ .Values.telegraf_sidecar.image.tag }}"

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -111,7 +111,7 @@ spec:
           - name: KUBE_NAMESPACE
             value: {{ .Release.Namespace }}
         command: ["/docker-entrypoint.sh"]
-        args: ["/bin/sh","-c","/wait-for $JOBS_DB_HOST:$(JOBS_DB_PORT) {{ if (include "statsd.enabled" .) -}} -- /wait-for -u {{ include "statsd.url" .}} {{- end }} -- {{include "backend.binary" .}} {{ .Values.backend.cliArgs }}"]
+        args: ["/bin/sh","-c","/wait-for $JOBS_DB_HOST:$(JOBS_DB_PORT) {{ if (include "statsd.enabled" .) -}} -- /wait-for -u {{ include "statsd.url" .}} {{- end }} -- /rudder-server"]
         {{- if .Values.telegraf_sidecar.enabled}}
       - name: {{ include "telegraf-sidecar.name" .}}
         image: "{{ .Values.telegraf_sidecar.image.repo }}:{{ .Values.telegraf_sidecar.image.tag }}"

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -30,11 +30,13 @@ spec:
             defaultMode: 420
             name: {{ include "backend.fullname" . }}-config
           name: backend-config-volume
+        {{- if .Values.telegraf_sidecar }}
         {{- if .Values.telegraf_sidecar.enabled}}
         - name: telegraf
           configMap:
             defaultMode: 420
             name: {{ include "telegraf-sidecar.fullname" . }}-config
+        {{- end }}
         {{- end }}
         {{- if .Values.gcpCredentialSecret.enabled }}
         - name: google-application-credentials
@@ -109,7 +111,7 @@ spec:
           - name: KUBE_NAMESPACE
             value: {{ .Release.Namespace }}
         command: ["/docker-entrypoint.sh"]
-        args: ["/bin/sh","-c","/wait-for $JOBS_DB_HOST:$(JOBS_DB_PORT) {{ if eq (include "statsd.enabled" .) "true" -}} -- /wait-for -u {{ include "statsd.url" .}} {{- end }} -- {{include "backend.binary" .}} {{ .Values.backend.cliArgs }}"]
+        args: ["/bin/sh","-c","/wait-for $JOBS_DB_HOST:$(JOBS_DB_PORT) {{ if (include "statsd.enabled" .) -}} -- /wait-for -u {{ include "statsd.url" .}} {{- end }} -- {{include "backend.binary" .}} {{ .Values.backend.cliArgs }}"]
         {{- if .Values.telegraf_sidecar.enabled}}
       - name: {{ include "telegraf-sidecar.name" .}}
         image: "{{ .Values.telegraf_sidecar.image.repo }}:{{ .Values.telegraf_sidecar.image.tag }}"

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@
 
 # Please uncomment below lines and fill values accordingly.
 # Please enter api token obtained from rudder dashboard below or specify existing secret, that contains rudderWorkspaceToken key
-rudderWorkspaceToken: yhdkjfhdjfbd
+# rudderWorkspaceToken:
 # rudderWorkspaceTokenExistingSecret:
 
 gcpCredentialSecret:

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@
 
 # Please uncomment below lines and fill values accordingly.
 # Please enter api token obtained from rudder dashboard below or specify existing secret, that contains rudderWorkspaceToken key
-# rudderWorkspaceToken:
+rudderWorkspaceToken: yhdkjfhdjfbd
 # rudderWorkspaceTokenExistingSecret:
 
 gcpCredentialSecret:


### PR DESCRIPTION
## Making sure telegraf comes up before rudder server
> Currently there is no wait-for condition on telegraf. This causes rudder server to spin up before telegraf because of which metrics are lost until and unless the rudderserver is restarted. Fixing this issue by adding wait for condition when telegraf sidecar is enabled..

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
