### PR TITLE
feat: update transformer image org to rudderstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ The following table lists the configurable parameters of the Rudderstack chart a
 | `backend.image.version`                 | Container image tag for the backend. [Available versions](https://hub.docker.com/r/rudderlabs/rudder-server/tags)                                                                 | `v0.1.6`                  |
 | `backend.image.pullPolicy`     | Container image pull policy for the backend image                                                   | `Always`           |
 | `backend.config.overrides` | object | `{}` | rudder-server config overrides See [config parameters](https://docs.rudderlabs.com/administrators-guide/config-parameters) for more details |
-| `transformer.image.repository`      | Container image repository for the transformer                                                      | `rudderlabs/transformer` |
-| `transformer.image.version`             | Container image tag for the transformer. [Available versions](https://hub.docker.com/r/rudderlabs/rudder-transformer/tags)                                                            | `v0.1.2`                  |
+| `transformer.image.repository`      | Container image repository for the transformer                                                      | `rudderstack/transformer` |
+| `transformer.image.version`             | Container image tag for the transformer. [Available versions](https://hub.docker.com/r/rudderstack/rudder-transformer/tags)                                                            | `latest`                  |
 | `transformer.image.pullPolicy` | Container image pull policy for the transformer image                                               | `Always`           |
 | `backend.extraEnvVars`              | Extra environments variables to be used by the backend in the deployments                           | `Refer values.yaml file` |
 | `backend.controlPlaneJSON`                   | If `true`, backend will read config from the workspaceConfig.json file  |  `false` |

--- a/values.yaml
+++ b/values.yaml
@@ -106,7 +106,7 @@ transformer:
   service:
     port: 9090
   image:
-    repository: rudderlabs/rudder-transformer
+    repository: rudderstack/rudder-transformer
     version: latest
     pullPolicy: Always
   resources:


### PR DESCRIPTION
## Description of the change

> Updating the transformer repo org being used by open source customers here to rudderstack. This is related to the migration being done [here](https://github.com/rudderlabs/rudder-devops/pull/5286) and [here](https://github.com/rudderlabs/rudder-devops/pull/5287)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
