### PR TITLE
fix: add mandatory env for OSS users of Shopify

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -100,6 +100,9 @@ backend:
       value: "/etc/rudderstack/google-application-credentials.json"
     - name: LOG_LEVEL
       value: "INFO"  # eg. DEBUG, ERROR
+      # DO NOT REMOVE - Mandatory env for Shopify
+    - name: RSERVER_GATEWAY_WEBHOOK_SOURCE_LIST_FOR_PARSING_PARAMS
+      value: Shopify
 
 transformer:
   replicaCount: 1


### PR DESCRIPTION
## Description of the change

> We recently had an open source user who was facing issues in running Shopify in their OSS deployment. On debugging, we found that an env that we set automatically in our deployments, was not done for in case of OSS users, leading to failure in Shopify Cloud mode.

Adding `WEBHOOK_SOURCE_LIST_FOR_PARSING_PARAMS` in the values.yaml

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
