### PR TITLE
feat: add optional k8s serviceAccount creation

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ The following table lists the configurable parameters of the Rudderstack chart a
 | `transformer.image.pullPolicy` | Container image pull policy for the transformer image                                               | `Always`           |
 | `backend.extraEnvVars`              | Extra environments variables to be used by the backend in the deployments                           | `Refer values.yaml file` |
 | `backend.controlPlaneJSON`                   | If `true`, backend will read config from the workspaceConfig.json file  |  `false` |
+| `serviceAccount.create` | Enable service account creation. | `true` |
+| `serviceAccount.annotations` | Annotations to be added to the service account. | `{}` |
+| `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""` |
 
 Each of these parameters can be changed in `values.yaml`. Or specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -93,6 +93,17 @@ Return the appropriate apiVersion for statefulset.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rudderstack.serviceAccountName" -}}
+{{- if .Values.rbac.create }}
+{{- default (include "rudderstack.fullname" .) .Values.rbac.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.rbac.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
 {{- define "statsd.enabled" -}}
 {{- if .Values.telegraf_sidecar -}}
 {{- if .Values.telegraf_sidecar.enabled }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -97,10 +97,10 @@ Return the appropriate apiVersion for statefulset.
 Create the name of the service account to use
 */}}
 {{- define "rudderstack.serviceAccountName" -}}
-{{- if .Values.rbac.create }}
-{{- default (include "rudderstack.fullname" .) .Values.rbac.serviceAccount.name }}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "rudderstack.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.rbac.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,11 +1,11 @@
 ---
-{{ if .Values.rbac.create -}}
+{{ if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "rudderstack.serviceAccountName" . }}
   labels:
-  {{- with .Values.rbac.serviceAccount.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+{{ if .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rudderstack.serviceAccountName" . }}
+  labels:
+  {{- with .Values.rbac.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -23,6 +23,7 @@ spec:
         checksum/rudder-config: {{ $rudderConfig | toYaml | sha256sum }}
         checksum/rudder-bigquery-credentials: {{ .Files.Get "bigquery-credentials.json" | sha256sum }}
     spec:
+      serviceAccountName: {{ include "rudderstack.serviceAccountName" . }}
     {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -118,15 +118,16 @@ transformer:
     limits:
       memory: 768Mi
 
-## Enable RBAC
-rbac:
+serviceAccount:
+  # -- Enable service account creation.
   create: false
-  serviceAccount:
-    # Annotations to add to the service account
-    annotations: {}
-    # The name of the service account to use.
-    # If not set and create is true, a name is generated using the fullname template
-    name: ""
+
+  # -- Annotations to be added to the service account.
+  annotations: {}
+
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
 
 postgresql:
   nameOverride: "rudderstack-postgresql"

--- a/values.yaml
+++ b/values.yaml
@@ -118,6 +118,16 @@ transformer:
     limits:
       memory: 768Mi
 
+## Enable RBAC
+rbac:
+  create: false
+  serviceAccount:
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
 postgresql:
   nameOverride: "rudderstack-postgresql"
   postgresqlUsername: rudder


### PR DESCRIPTION
## Description of the change

> Adds support for optionally creating a kubernetes service account

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
