### PR TITLE
feat: add optional additional labels to resources

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v2
 name: rudderstack
 description: Privacy and Security focused Segment-alternative, in Golang and React
@@ -14,7 +15,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The following table lists the configurable parameters of the Rudderstack chart a
 | `serviceAccount.create` | Enable service account creation. | `true` |
 | `serviceAccount.annotations` | Annotations to be added to the service account. | `{}` |
 | `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""` |
+| `transformer.commonLabels` | Labels to apply to all transformer resources | `{}` |
 
 Each of these parameters can be changed in `values.yaml`. Or specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,19 @@ The following table lists the configurable parameters of the Rudderstack chart a
 
 | Parameter                           | Description                                                                                         | Default                  |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------ |
+| `commonLabels` | Labels to apply to all resources | `{}` |
 | `rudderWorkspaceToken`              | Workspace token from the dashboard                                                                  | `-`                      |
 | `rudderWorkspaceTokenExistingSecret`    | Secret with workspace token (overrides `rudderWorkspaceToken`)                                                                 | `-`                      |
 | `backend.image.repository`          | Container image repository for the backend                                                          | `rudderlabs/rudder-server`     |
 | `backend.image.version`                 | Container image tag for the backend. [Available versions](https://hub.docker.com/r/rudderlabs/rudder-server/tags)                                                                 | `v0.1.6`                  |
 | `backend.image.pullPolicy`     | Container image pull policy for the backend image                                                   | `Always`           |
+| `backend.ingress.annotations` | Annotations to be added to backend ingress | `{}` |
+| `backend.ingress.labels` | Labels to be added to backend ingress | `{}` |
+| `backend.service.annotations` | Annotations to be added to backend service | `{"service.beta.kubernetes.io/aws-load-balancer-backend-protocol":"http"}` |
+| `backend.service.labels` | Labels to be added to backend service | `{}` |
+| `backend.podLabels` | Labels to add to the backend pod container metadata | `{}` |
+| `backend.podAnnotations` | Annotations to be added to backend pods | `{}` |
+| `backend.labels` | Labels to be added to the controller StatefulSet and other resources that do not have option to specify labels | `{}` |
 | `backend.config.overrides` | object | `{}` | rudder-server config overrides See [config parameters](https://docs.rudderlabs.com/administrators-guide/config-parameters) for more details |
 | `transformer.image.repository`      | Container image repository for the transformer                                                      | `rudderstack/transformer` |
 | `transformer.image.version`             | Container image tag for the transformer. [Available versions](https://hub.docker.com/r/rudderstack/rudder-transformer/tags)                                                            | `latest`                  |

--- a/charts/transformer/templates/_helpers.tpl
+++ b/charts/transformer/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "transformer.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "rudderstack.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/templates/configmap-rudder-server.yaml
+++ b/templates/configmap-rudder-server.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: {{ include "backend.name" . }}
     release: {{ .Release.Name | quote }}
+    {{- include "rudderstack.labels" . | nindent 4 }}
 data:
   config.yaml: |-
     {{ $mergedConfig | toYaml | nindent 4 }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ include "rudderstack.fullname" . }}
   labels:
     {{- include "rudderstack.labels" . | nindent 4 }}
+  {{- with .Values.backend.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.backend.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
   {{- with .Values.backend.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -4,6 +4,12 @@ metadata:
   name: {{ include "rudderstack.fullname" . }}
   labels:
     {{- include "rudderstack.labels" . | nindent 4 }}
+  {{- with .Values.backend.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.backend.service.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   annotations:
   {{- with .Values.backend.service.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -5,6 +5,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "rudderstack.serviceAccountName" . }}
   labels:
+    {{- include "rudderstack.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "rudderstack.fullname" . }}
   labels:
     {{- include "rudderstack.labels" . | nindent 4 }}
+    {{- with .Values.backend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   serviceName: {{ include "rudderstack.fullname" . }}
   replicas: {{ .Values.global.backendReplicaCount }}
@@ -15,13 +18,22 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "rudderstack.selectorLabels" . | nindent 8 }}
+        {{- include "rudderstack.labels" . | nindent 8 }}
+        {{- with .Values.backend.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.backend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- if not .Values.rudderWorkspaceTokenExistingSecret }}
         checksum/rudder-workspace-token: {{ include (print $.Template.BasePath "/secret-rudder-token.yaml") . | sha256sum }}
         {{- end }}
         checksum/rudder-config: {{ $rudderConfig | toYaml | sha256sum }}
         checksum/rudder-bigquery-credentials: {{ .Files.Get "bigquery-credentials.json" | sha256sum }}
+        {{- with .Values.backend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "rudderstack.serviceAccountName" . }}
     {{- with .Values.global.imagePullSecrets }}
@@ -147,8 +159,8 @@ spec:
         storageClassName: {{ .Values.global.storageClass }}
         accessModes:
         {{- range .Values.backend.persistence.accessModes }}
-         - {{ . | quote }}
+          - {{ . | quote }}
         {{- end }}
         resources:
           requests:
-           storage: {{ .Values.backend.persistence.size | quote }}
+            storage: {{ .Values.backend.persistence.size | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
+---
 # Deployment specific values for rudderstack.
 # Following values must be filled in for the deployment to succeed
 
@@ -10,6 +10,10 @@
 # Please enter api token obtained from rudder dashboard below or specify existing secret, that contains rudderWorkspaceToken key
 rudderWorkspaceToken: replaceMe
 # rudderWorkspaceTokenExistingSecret:
+
+# -- Labels to apply to all resources
+commonLabels: {}
+# myLabel: aakkmd
 
 gcpCredentialSecret:
   enabled: false
@@ -37,17 +41,23 @@ backend:
   ingress:
     enabled: false
     tls: false
+    # -- Annotations to be added to backend ingress
     annotations: {}
+    # -- Labels to be added to backend ingress
+    labels: {}
     hostname: "rudderstack.local"
     # optional override for tls secret name
     # secretName: rudderstack-tls
   service:
+    # -- Annotations to be added to backend service
     annotations:
       ## Refer https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer for more annotations
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
       ## For enabling https on aws,
       ## uncomment below line with acm managed certificate arn and change port value below to 443
       # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012
+    # -- Labels to be added to backend service
+    labels: {}
     type: LoadBalancer
     port: 80
     targetPort: 8080
@@ -56,6 +66,10 @@ backend:
       memory: 2560Mi
     limits:
       memory: 5120Mi
+  # -- Labels to add to the backend pod container metadata
+  podLabels: {}
+  # -- Annotations to be added to backend pods
+  podAnnotations: {}
 
   nodeSelector: {}
 
@@ -103,6 +117,9 @@ backend:
       # DO NOT REMOVE - Mandatory env for Shopify
     - name: RSERVER_GATEWAY_WEBHOOK_SOURCE_LIST_FOR_PARSING_PARAMS
       value: Shopify
+
+  # -- Labels to be added to the controller StatefulSet and other resources that do not have option to specify labels
+  labels: {}
 
 transformer:
   replicaCount: 1


### PR DESCRIPTION
## Description of the change

> Allow adding arbitrary labels to different resources in the chart. Useful for monitoring and other things, and fairly common. I followed example code from the [ingress-nginx](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/templates/_helpers.tpl) and [argo-cd](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/argocd-server/deployment.yaml) charts.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
