### PR TITLE
feat: add support for external database configuration [PLT-1343]

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -33,3 +33,7 @@ appVersion: 1.4.3
 #     import-values: # (optional)
 #       - ImportValues holds the mapping of source values to parent key to be imported. Each item can be a string or pair of child/parent sublist items.
 #     alias: (optional) Alias usable alias to be used for the chart. Useful when you have to add the same chart multiple times
+#
+# Note: The postgresql chart is included as a local subchart in charts/postgresql/
+# When postgresql.enabled is false, you should remove or rename the charts/postgresql
+# directory to prevent it from being deployed, or it will be deployed but not used.

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -103,6 +103,7 @@ spec:
             {{- end}}
           - name: DEST_TRANSFORM_URL
             value: "http://{{ include "transformer.fullname" . }}:{{ .Values.transformer.service.port}}"
+          {{- if .Values.postgresql.enabled }}
           - name: COMPUTE_DB_HOST_IN_K8S
             value: "true"
           - name: POSTGRES_POD_NAME
@@ -114,11 +115,55 @@ spec:
           - name: JOBS_DB_USER
             value: "{{ .Values.postgresql.postgresqlUsername }}"
           - name: JOBS_DB_PORT
-            value: "{{ .Values.postgresql.service.port }}"
+            value: "{{ .Values.postgresql.service.port | toString }}"
           - name: JOBS_DB_DB_NAME
             value: "{{ .Values.postgresql.postgresqlDatabase }}"
           - name: JOBS_DB_PASSWORD
             value: "{{ .Values.postgresql.postgresqlPassword }}"
+          {{- else }}
+          - name: COMPUTE_DB_HOST_IN_K8S
+            value: "false"
+          {{- if .Values.externalDatabase.existingSecret }}
+          # All database values from secret
+          - name: JOBS_DB_HOST
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.externalDatabase.existingSecret }}
+                key: {{ .Values.externalDatabase.existingSecretKeys.host }}
+          - name: JOBS_DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.externalDatabase.existingSecret }}
+                key: {{ .Values.externalDatabase.existingSecretKeys.user }}
+          - name: JOBS_DB_PORT
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.externalDatabase.existingSecret }}
+                key: {{ .Values.externalDatabase.existingSecretKeys.port }}
+          - name: JOBS_DB_DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.externalDatabase.existingSecret }}
+                key: {{ .Values.externalDatabase.existingSecretKeys.database }}
+          - name: JOBS_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.externalDatabase.existingSecret }}
+                key: {{ .Values.externalDatabase.existingSecretKeys.password }}
+          {{- else }}
+          # Database values from direct configuration
+          - name: JOBS_DB_HOST
+            value: "{{ required "externalDatabase.host is required when postgresql.enabled is false and existingSecret is not set" .Values.externalDatabase.host }}"
+          - name: JOBS_DB_USER
+            value: "{{ required "externalDatabase.user is required when postgresql.enabled is false and existingSecret is not set" .Values.externalDatabase.user }}"
+          - name: JOBS_DB_PORT
+            value: "{{ .Values.externalDatabase.port | toString }}"
+          - name: JOBS_DB_DB_NAME
+            value: "{{ required "externalDatabase.database is required when postgresql.enabled is false and existingSecret is not set" .Values.externalDatabase.database }}"
+          - name: JOBS_DB_PASSWORD
+            value: "{{ required "externalDatabase.password is required when postgresql.enabled is false and existingSecret is not set" .Values.externalDatabase.password }}"
+          {{- end }}
+          {{- end }}
           - name: INSTANCE_ID
             valueFrom:
               fieldRef:

--- a/values.yaml
+++ b/values.yaml
@@ -146,7 +146,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template.
   name: ""
 
+# -- Enable internal PostgreSQL subchart deployment
+# When set to false, you must provide externalDatabase configuration
 postgresql:
+  enabled: true
   nameOverride: "rudderstack-postgresql"
   postgresqlUsername: rudder
   postgresqlPassword: password
@@ -169,6 +172,32 @@ postgresql:
       memory: 2048Mi
     limits:
       memory: 4096Mi
+
+# -- External database configuration
+# Use this when postgresql.enabled is false to connect to an external database
+externalDatabase:
+  # -- Host of the external database (or use existingSecret)
+  host: ""
+  # -- Port of the external database (or use existingSecret)
+  port: 5432
+  # -- Database name (or use existingSecret)
+  database: "jobsdb"
+  # -- Username for the external database (or use existingSecret)
+  user: "rudder"
+  # -- Password for the external database (or use existingSecret)
+  password: ""
+  # -- Existing secret containing database connection details
+  # If set, all database values (host, port, database, user, password) will be taken from this secret
+  # If not set, values will be taken from the fields above
+  existingSecret: ""
+  # -- Keys in the existing secret for each database field
+  # Only used when existingSecret is set
+  existingSecretKeys:
+    host: "host"
+    port: "port"
+    database: "database"
+    user: "user"
+    password: "password"
 
 telegraf_sidecar:
   enabled: true


### PR DESCRIPTION
- Make internal PostgreSQL optional via postgresql.enabled flag
- Add externalDatabase configuration section with support for:
  - Direct values (host, port, database, user, password)
  - All values from Kubernetes secret (existingSecret)
- Update statefulset to conditionally use internal or external database
- Add validation for required fields when using external database
- Update README with documentation and examples
- Maintain backward compatibility (postgresql.enabled defaults to true)